### PR TITLE
chore: add CODEOWNSERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, @SJD-Die-Falken/maintainers will
+# be requested for review when someone opens a pull request.
+
+*                     @SJD-Die-Falken/maintainers


### PR DESCRIPTION
Add `CODEOWNSERS` to set default reviewers on PRs.