### PR TITLE
chore: remove noStrictGenericChecks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noImplicitUseStrict": false,
-    "noStrictGenericChecks": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": false,


### PR DESCRIPTION
Remove the `noStrictGenericChecks` argument from the `tsconfig.json` as it has been deprecated in v5 and will be unusable in v5.5